### PR TITLE
Fix wrong variable in receive_commands

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -209,7 +209,7 @@ def receive_commands(socket):
         
         if command.startswith("download"):
             filename = command.split(" ", 1)[1]  # Extrait le nom du fichier de la commande
-            send_file(client_socket, filename)
+            send_file(socket, filename)
 
         if command.startswith("START_FILE_UPLOAD"):
             file_name = command.split(":", 1)[1].strip()


### PR DESCRIPTION
## Summary
- use the proper socket argument when sending files in `receive_commands`

## Testing
- `python -m py_compile agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68407319c2e4833392eb9d461b4f6ff0